### PR TITLE
fix: input tensor size formula of the regressor for affine matrix

### DIFF
--- a/Classifier/network.py
+++ b/Classifier/network.py
@@ -83,7 +83,7 @@ class CNN_STN(nn.Module):
                 #nn.MaxPool2d(2, stride=2)
         )
         
-        # input units: ( [[((32/2)-4)/2] -2 ] )**2 * 300 = 4**4 * 300
+        # input units: ( [[((32/2)-4)/2] -2 ] )**2 * 300 = 4**2 * 300
         #               \_______________________/     \
         #             output tensor size           channels
         


### PR DESCRIPTION
I was struggling calculating the dimension after reading PyTorch's Spatial Transformer Networks Tutorial
https://pytorch.org/tutorials/intermediate/spatial_transformer_tutorial.html

The formula here really helps undertand, thanks @N0Wire !